### PR TITLE
Do not include quotes in PATH

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     state: present
     backrefs: yes
     regexp: 'PATH=(["]*)((?!.*?{{cuda_path}}/bin).*?)(["]*)$'
-    line: 'PATH=\1"{{cuda_path}}/bin":\2\3'
+    line: 'PATH=\1{{cuda_path}}/bin:\2\3'
 
 - include: recommended.yml
   when: "{{cuda_install_recommended}}"


### PR DESCRIPTION
There can be parsing errors, when there are quotes in the PATH environment variable. Unless the cuda_path contains spaces the quotes shouldn't be needed and cuda_path should never contain spaces, as that would be rather dangerous. (And in practise if you install cuda from the debian repository it will never contain spaces.)